### PR TITLE
A simpler (and maybe more robust?) way to do get axes values

### DIFF
--- a/osh5def.py
+++ b/osh5def.py
@@ -26,7 +26,7 @@ class DataAxis:
         if data is None:
             if axis_min > axis_max:
                 raise Exception('illegal axis range: [ %(l)s, %(r)s ]' % {'l': axis_min, 'r': axis_max})
-            self.ax = np.linspace(axis_min, axis_max - (axis_max - axis_min) / axis_npoints, axis_npoints)
+            self.ax = np.linspace( axis_min, axis_max, axis_npoints, endpoint=False )
         else:
             self.ax = data
         # now make attributes for axis that are required..


### PR DESCRIPTION
I noticed you fixed this from the previous arange implementation to avoid possible roundoff error.  However, there is an endpoint argument to the linspace function that does this for you.  Might be a bit more clear what's going on here.