### PR TITLE
Update osh5utils.py

### DIFF
--- a/osh5utils.py
+++ b/osh5utils.py
@@ -593,7 +593,7 @@ def field_decompose(fldarr, ffted=True, idim=None, finalize=None, outquants=('L'
     if not finalize:
         finalize = __idle
     if np.issubdtype(fldarr[0].dtype, np.floating):
-        ftf, iftf = fftn, ifftn if norft else rfftn, irfftn
+        ftf, iftf = (fftn, partial(ifftn, result=np.real(result))) if norft else (rfftn, irfftn)
 
     def wrap_up(data):
         if idim:


### PR DESCRIPTION
fix a small error in field-decompose.  

without the fix you will receive an error message when you call this routine @ NERSC (running python 3.9.7)